### PR TITLE
Fixed issue where examples didn't loop over the complete output.

### DIFF
--- a/src/main/java/KaufmanAdaptiveMovingAverageExample.java
+++ b/src/main/java/KaufmanAdaptiveMovingAverageExample.java
@@ -31,16 +31,16 @@ public class KaufmanAdaptiveMovingAverageExample {
 
 
         if (retCode == RetCode.Success) {
-            System.out.println("Output Begin:" + begin.value);
-            System.out.println("Output End:" + length.value);
+            System.out.println("Output Start Period: " + begin.value);
+            System.out.println("Output End Period: " + (begin.value + length.value - 1));
 
-            for (int i = begin.value; i <= length.value; i++) {
+            for (int i = begin.value; i < begin.value + length.value; i++) {
                 StringBuilder line = new StringBuilder();
                 line.append("Period #");
                 line.append(i);
-                line.append(" close= ");
+                line.append(" close=");
                 line.append(closePrice[i]);
-                line.append(" mov avg=");
+                line.append(" mov_avg=");
                 line.append(out[i-begin.value]);
                 System.out.println(line.toString());
             }

--- a/src/main/java/SimpleMovingAverageExample.java
+++ b/src/main/java/SimpleMovingAverageExample.java
@@ -29,17 +29,17 @@ public class SimpleMovingAverageExample {
 
 
         if (retCode == RetCode.Success) {
-            System.out.println("Output Begin:" + begin.value);
-            System.out.println("Output End:" + length.value);
+            System.out.println("Output Start Period: " + begin.value);
+            System.out.println("Output End Period: " + (begin.value + length.value - 1));
 
-            for (int i = begin.value; i <= length.value; i++) {
+            for (int i = begin.value; i < begin.value + length.value; i++) {
                 StringBuilder line = new StringBuilder();
                 line.append("Period #");
                 line.append(i);
-                line.append(" close= ");
+                line.append(" close=");
                 line.append(closePrice[i]);
-                line.append(" mov avg=");
-                line.append(out[i-begin.value]);
+                line.append(" mov_avg=");
+                line.append(out[i - begin.value]);
                 System.out.println(line.toString());
             }
         }


### PR DESCRIPTION
As discussed before I updated the examples to loop over the complete output. This was caused by the fact that length.value contains the amount of output results, and not the index of the last output result as was assumed in the original version. 